### PR TITLE
Mise à jour lien couverture

### DIFF
--- a/content/couverture.md
+++ b/content/couverture.md
@@ -28,7 +28,7 @@ Autres contributeurs :
 
 * En vrac pour des corrections et typos : 
   [Denis Roussel](https://github.com/KuiKui), 
-  [Benjamin Dos Santos](https://github.com/Benjamin-Ds),
+  [Benjamin Dos Santos](https://github.com/bdossantos),
   [DirtyF](https://github.com/DirtyF), Tanguy Martin,
   [Tomhtml](https://github.com/TOMHTML), 
   [Franek](https://github.com/franek),


### PR DESCRIPTION
Bonjour Éric,

J'ai changé mon nom d'utilisateur et l'ancien lien pointe maintenant vers une 404 ...

Merci d'avance,
